### PR TITLE
Better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+## 5.0.2 - 2018-11-29
+
+  * Bug fix: publish() didn't wait for the write buffer to drain.
+
+## 5.0.1 - 2018-08-07
+
+  * Bug fix: publish() didn't reject properly if the client was
+    shutting down.
+
+## 5.0.0 - 2018-07-31
+
+  * Improved shutdown handling. 
+  * Syntax to access the library has been changed to improve
+    connection management. See [Running](README.md#running) for
+    details.
+
 ## 4.2.0 - 2018-01-30
 
   * `setMaxListeners()` on the created channel in order to avoid

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ need to at minimum specify either
 or
 * `url`.
 
-### `local`
-
-If true, means there will be no AMQP connection. Default: false
-
 ### `rpc`
 
 * `timeout`: timeout in ms for rpc calls. Default: 1000ms
@@ -120,7 +116,6 @@ do this is to attach an `error` event handler.
             "password": "supersecret"
         },
         "logLevel": "warn",
-        "local": false,
         "rpc": {
             "timeout": 2000
         }
@@ -330,10 +325,6 @@ Shorthand for
 
 Will unbind all queues and unsubscribe all callbacks then gracefully
 shut down the socket connection.
-
-### `amqpc.local`
-
-Read only property that tells whether `conf.local` was true.
 
 ## The `exchange` object
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ If true, means there will be no AMQP connection. Default: false
 
 ### `errorHandler`
 
-*Since 2.0.0* connection errors are rethrown to crash process.
+*Since 2.0.0* connection errors are rethrown to crash process. 
 
-* `errorHandler`: sets a handler function to receive the error instead of
-throwing to process.
+* `errorHandler`: sets a handler function to receive the error instead
+of throwing to process. This option is deprecated, as a better way to
+do this is to attach an `error` event handler.
 
 ### `waitForConnection`
 
@@ -134,6 +135,30 @@ Or with url:
         "logLevel": "warn"
     }
 
+
+Events
+=======
+
+Amqp-as-promised emits `error` events on unexpected network errors,
+for example then the connection to the server has been lost. It is up
+to the client to handle these errors, as amqp-as-promised doesn't
+reconnect automatically. Keep in mind that error recovery can be
+tricky, and the best option might be to just crash and restart the
+application on error.
+
+This is a simple but effective error handler:
+
+    amqpc.on 'error', (err) ->
+        console.log err
+        process.exit 1
+
+## Unhandled errors
+
+If there are no error handlers attached (either using `amqp.on()` or
+setting the `errorHandler` in the configuration), amqp-as-promised
+will as a last resort throw the error. This will most likely result in
+an application crash unless there is an uncaught exception handler set
+on the `process`.
 
 Examples
 ==========
@@ -259,6 +284,10 @@ API
 ===
 
 ## The `amqpc` object
+
+### `amqpc.on(event, handler)`
+
+Attach an event handler. Currently only `error` events are supported.
 
 ### `amqpc.exchange(name, opts)`
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ AMQP as Promised
 ![Monthly downloads](http://img.shields.io/npm/dm/amqp-as-promised.svg) &nbsp;
 ![Build Status](https://ci2.tt.se/buildStatus/icon\?job\=ttab/amqp-as-promised/master)
 
-A high-level [promise-based](https://github.com/kriskowal/q) API built on
+A high-level [promise-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) API built on
 [`amqplib`](https://www.npmjs.com/package/amqplib)
 extended with functions for AMQP-based RPC.
 
 * [`amqplib` API docs][amqplib-api-docs]
 * Old versions of this package were based on [node-amqp][npm-node-amqp].
 
-  [amqplib-api-docs]: (http://www.squaremobius.net/amqp.node/channel_api.html)
+  [amqplib-api-docs]: http://www.squaremobius.net/amqp.node/channel_api.html
   [npm-node-amqp]: https://github.com/postwait/node-amqp
 
 ## Table of contents
@@ -31,7 +31,9 @@ extended with functions for AMQP-based RPC.
 
 #### 5.0
 
-Syntax to access the library has been changed in 5.0 to improve connection management. See the [Running](#running)-section for instructions.
+Syntax to access the library has been changed in 5.0 to improve
+connection management. See the [Running](#running)-section for
+instructions.
 
 #### 3.0
 
@@ -123,6 +125,7 @@ do this is to attach an `error` event handler.
 
 Or with url:
 
+
     {
         "connection": {
             "url": "amqp://myuser:supersecret@192.168.0.10/test"
@@ -143,9 +146,11 @@ application on error.
 
 This is a simple but effective error handler:
 
-    amqpc.on 'error', (err) ->
-        console.log err
-        process.exit 1
+```coffee
+amqpc.on 'error', (err) ->
+    console.log err
+    process.exit 1
+```
 
 ## Unhandled errors
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,6 +17,7 @@ module.exports = (conf = {}) -> new Promise (resolve, reject) ->
         rpcBackend = new RpcBackend client
 
         return resolve({
+            on: client.on.bind(client)
             exchange: client.exchange
             queue: client.queue
             bind: client.bind

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -24,7 +24,6 @@ module.exports = (conf = {}) -> new Promise (resolve, reject) ->
             rpc: rpc.rpc
             serve: rpcBackend.serve
             shutdown: client.shutdown
-            local: client.local
         })
     .catch (err) ->
         reject(err)


### PR DESCRIPTION
Fixes the (kinda) broken error handling, by listening for unexpected `close`events and emitting our own error events. If the client has not attached an error handler, this will instead throw an exception and potentially crash the process, which has been the intended behaviour since 2.0, but has worked poorly since the switch to amqplib.